### PR TITLE
fix youtube not staying paused

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -37,7 +37,13 @@ chrome.storage.local.get({ whitelist: [] }, (data) => {
     }
 
     // Detect first user interaction
-    const markInteracted = () => {
+    const markInteracted = (event) => {
+        if (userInteracted) return;
+        if (event && event.isTrusted === false) {
+            if (DEBUG) console.log("[AutoplayStopper] Ignoring synthetic interaction:", event.type);
+            return;
+        }
+
         userInteracted = true;
         if (DEBUG) console.log("[AutoplayStopper] User interaction → media allowed");
     };


### PR DESCRIPTION
This was coded by GPT-5 Codex Medium in Github Copilot. I didn't bother understanding the change so I'm sorry. But it seems to work. The video can still play for less than a second but that's good enough for me. Also, it only stops tab refresh. Not clicking on a video from YouTube itself. You can just close this.

**Here is GHC's conclusion:**

A synthetic pointerdown/keydown that YouTube fires during boot was fooling our listener into thinking a real human had clicked, which immediately flipped [userInteracted](vscode-file://vscode-app/c:/Users/dovie/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to true, shut down the watchdog loop, and let the video resume seconds later. I updated the interaction handler to require [event.isTrusted](vscode-file://vscode-app/c:/Users/dovie/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html), so only genuine user input unlocks playback. When synthetic events arrive, we now briefly log that they were ignored and keep the blockade running.

### files changed
content.js – Hardened the interaction detection logic to ignore untrusted/synthetic events before marking the user as having interacted.
testing
No automated test suite is present for this MV3 project. Please load the unpacked extension, open a fresh YouTube watch page, and confirm the video remains paused until you manually interact. Revoke interaction (e.g., reload the page) to verify the block persists.
#### todo ✅
 Reproduce and analyze the premature autoplay on YouTube.
 Prevent synthetic events from toggling [userInteracted](vscode-file://vscode-app/c:/Users/dovie/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
 Verify no additional regression risks and document manual testing guidance.
#### notes
Once you confirm on YouTube, keep an eye on any sites that legitimately dispatch custom Event objects tied to real hardware input—those should still come through with [isTrusted = true](vscode-file://vscode-app/c:/Users/dovie/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html), so we’re good. If you encounter platforms that synthesize trusted events, we can extend the guard with heuristics per domain.